### PR TITLE
Fix request session context manager

### DIFF
--- a/amberdata_rest/common.py
+++ b/amberdata_rest/common.py
@@ -122,7 +122,7 @@ class RestService(ABC):
                       retry_count: int = 5, sleep_duration: float = 10.0) -> [bool, object]:
         while retry_count > 0:
             lg.debug(f"Executing request with url:{url}, params={params}, retryCount:{retry_count}")
-            with requests.session() as session:
+            with requests.Session() as session:
                 try:
                     response_raw = session.get(url, headers=headers, params=params)
                     response_raw.raise_for_status()


### PR DESCRIPTION
## Summary
- fix `_get_response` to use the correct `requests.Session` context manager

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_6850a40f5250832d97c45731535333d6