### PR TITLE
Replace eval with json parsing

### DIFF
--- a/amberdata_rest/common.py
+++ b/amberdata_rest/common.py
@@ -339,5 +339,5 @@ def get_amberdata_api_key_from_local_file(file_path: str) -> str:
 def get_amberdata_api_key_from_aws_secret_manager(secret_name: str, secret_key: str) -> str:
     sm = SecretManager()
     secret_string = sm.get_secret(secret_name)
-    secret_dict = eval(secret_string)
+    secret_dict = json.loads(secret_string)
     return secret_dict[secret_key]


### PR DESCRIPTION
## Summary
- use `json.loads` when retrieving secrets from AWS
- preserve `json` import at the top of `common.py`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_6850a41930f0832d8925e290e1865fd2