### PR TITLE
Fix exchanges reference typo

### DIFF
--- a/amberdata_rest/spot/service.py
+++ b/amberdata_rest/spot/service.py
@@ -53,8 +53,8 @@ class SpotRestService(RestService):
         lg.info(f"Finished {description}")
         return return_dict
 
-    def get_exhanges_reference(self, exchanges: List[MarketDataVenue] = None, instruments: List[str] = None,
-                               include_inactive: bool = None, include_original_reference: bool = None) -> Dict:
+    def get_exchanges_reference(self, exchanges: List[MarketDataVenue] = None, instruments: List[str] = None,
+                                include_inactive: bool = None, include_original_reference: bool = None) -> Dict:
         params = {}
         if exchanges is not None and len(exchanges) > 0:
             params['exchange'] = ",".join(exchange.value for exchange in exchanges)

--- a/amberdata_rest/tests/spot/test_sport_service.py
+++ b/amberdata_rest/tests/spot/test_sport_service.py
@@ -119,7 +119,7 @@ class SpotRestTest(unittest.TestCase):
         self.assertTrue('avax_usdt' in pair_set, 'avax_usdt not in pair')
 
     def test_get_exchanges_reference_vanilla(self):
-        reference_data = srs.get_exhanges_reference()
+        reference_data = srs.get_exchanges_reference()
         self.assertTrue('data' in reference_data.keys(), 'data not in reference')
         exchange_set = set()
         binance_instrument_set = set()
@@ -132,8 +132,8 @@ class SpotRestTest(unittest.TestCase):
         self.assertTrue('eth_usdt' in binance_instrument_set, 'pairs not in reference')
         self.assertTrue('avax_usdt' in binance_instrument_set, 'pairs not in reference')
 
-    def test_test_get_exchanges_reference_specific_exchange(self):
-        reference_data = srs.get_exhanges_reference(exchanges=[MarketDataVenue.BINANCE, MarketDataVenue.COINBASE])
+    def test_get_exchanges_reference_specific_exchange(self):
+        reference_data = srs.get_exchanges_reference(exchanges=[MarketDataVenue.BINANCE, MarketDataVenue.COINBASE])
         self.assertTrue('data' in reference_data.keys(), 'data not in reference')
         exchange_set = set()
         binance_instrument_set = set()
@@ -146,8 +146,8 @@ class SpotRestTest(unittest.TestCase):
         self.assertTrue('eth_usdt' in binance_instrument_set, 'pairs not in reference')
         self.assertTrue('avax_usdt' in binance_instrument_set, 'pairs not in reference')
 
-    def test_test_get_exhanges_reference_specific_pair(self):
-        reference_data = srs.get_exhanges_reference(instruments=['btc_usdt', 'avax_usdt'])
+    def test_get_exchanges_reference_specific_pair(self):
+        reference_data = srs.get_exchanges_reference(instruments=['btc_usdt', 'avax_usdt'])
         self.assertTrue('data' in reference_data.keys(), 'data not in reference')
         exchange_set = set()
         instrument_set = set()


### PR DESCRIPTION
## Summary
- rename `get_exhanges_reference` -> `get_exchanges_reference`
- update tests to use new method name

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_6850a41dad8c832d8e0044060b9ce734